### PR TITLE
Add James Street dining guide

### DIFF
--- a/food/index.html
+++ b/food/index.html
@@ -72,6 +72,16 @@
                     </div>
                 </a>
             </div>
+            <div class="bg-white rounded-xl shadow-lg overflow-hidden transform hover:-translate-y-2 transition duration-300">
+                <a href="james-street-burleigh-dining-guide.html" aria-label="Read the James Street dining guide">
+                    <img src="https://images.pexels.com/photos/90946/pexels-photo-90946.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2" alt="People enjoying dinner at a bustling street restaurant" class="w-full h-48 object-cover">
+                    <div class="p-6">
+                        <h3 class="text-xl font-bold mb-2">James Street Burleigh Dining Guide</h3>
+                        <p class="text-gray-600 mb-4">Complete recommendations for cafés, bars, and restaurants on James Street.</p>
+                        <span class="font-semibold text-teal-500 hover:text-teal-600">Read More &rarr;</span>
+                    </div>
+                </a>
+            </div>
         </div>
     </main>
 

--- a/food/james-street-burleigh-dining-guide.html
+++ b/food/james-street-burleigh-dining-guide.html
@@ -1,0 +1,97 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <title>James Street Burleigh: Complete Dining Guide</title>
+    <meta name="description" content="Your local guide to the best cafes, bars, and restaurants along James Street in Burleigh Heads." />
+    <meta name="keywords" content="James Street Burleigh dining guide, Burleigh Heads restaurants, James Street cafes" />
+
+    <meta name="robots" content="noindex, nofollow">
+
+    <script src="https://cdn.tailwindcss.com"></script>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap" rel="stylesheet">
+
+    <style>
+        body {
+            font-family: 'Inter', sans-serif;
+        }
+    </style>
+</head>
+<body class="bg-white">
+
+    <header class="bg-white/90 backdrop-blur-md sticky top-0 z-50 shadow-sm">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex items-center justify-between">
+                <a href="/PG_Site/" class="text-2xl font-bold text-gray-900" aria-label="Back to ParadiseGrove.com Homepage">
+                    Paradise<span class="text-teal-500">Grove</span>.com
+                </a>
+                <a href="/PG_Site/food/" class="text-sm text-gray-500 hover:text-teal-500 transition duration-300">&larr; Back to Food &amp; Drink</a>
+            </div>
+        </nav>
+    </header>
+
+    <main class="container mx-auto px-6 py-12 max-w-4xl">
+        <article>
+            <header>
+                <p class="text-teal-600 font-semibold">Food &amp; Drink Guide</p>
+                <h1 class="text-4xl md:text-5xl font-extrabold leading-tight text-gray-900 mt-2 mb-6">James Street Burleigh: Complete Dining Guide</h1>
+            </header>
+
+            <p class="text-lg text-gray-700 leading-relaxed mb-6">
+James Street in Burleigh Heads has earned its reputation as the Gold Coast’s premier dining precinct. From relaxed cafés serving specialty coffee and healthy bites to neighbourhood bars offering curated wine lists and tapas-style plates, this vibrant strip caters to every palate and occasion. Real visitor feedback from TripAdvisor and other trusted sources ensures you will enjoy authentic, locally relevant recommendations that showcase Burleigh Heads’ unique culinary character.
+            </p>
+
+            <div class="space-y-10">
+                <section>
+                    <h2 class="text-3xl font-bold mb-3">Café Culture and Brunch Delights</h2>
+                    <p class="text-gray-700 mb-4">The heart of James Street’s daytime scene is its cafés, where locals gather for expertly brewed coffee and creative brunch fare.</p>
+                    <p class="text-gray-700 mb-4">Social Brew sets the standard for botanical-inspired décor and inventive breakfast dishes. Under a canopy of greenery, guests rave about the “Social Stack” pancake tower and the premium coffee options roasted to order. Early mornings offer the best chance to secure a table before the weekend crowds arrive.</p>
+                    <p class="text-gray-700 mb-4">Quest Burleigh Café delivers an intimate artisan experience with house-baked cakes, epic toasties, and a friendly, community atmosphere at 20 James Street. Reviewers praise the vegan and gluten-free choices alongside the café’s commitment to quality beans and attentive service.</p>
+                    <p class="text-gray-700 mb-4">Govindas brings a healthy tilt to the café lineup. As the top-ranked quick-bite spot on TripAdvisor, its vegetarian and vegan plates—such as the hearty salad bowls and energy-packed smoothie bowls—earn consistent praise for freshness and flavour.</p>
+                    <p class="text-gray-700">Helen’s Café and Juice Bar sits steps away with its reputation for the best acai bowls on the coast. Visitors describe the smoothies as “delicious and nourishing” and appreciate the café’s selection of vegan and vegetarian sandwiches to fuel a day of beach and shopping.</p>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-bold mb-3">Casual Lunch and Early Dinner</h2>
+                    <p class="text-gray-700 mb-4">As James Street transitions from brunch to lunch, several eateries stand out for their casual yet distinctive menus.</p>
+                    <p class="text-gray-700 mb-4">Burleigh Bar &amp; Bites offers a refined bar-and-snack concept in a cozy, velvet-lined space. Its share-style plates—such as garlic and chili prawns or lamb sliders—pair perfectly with craft cocktails and wine, making it a favourite for laid-back afternoons and early evening gatherings.</p>
+                    <p class="text-gray-700">Bunlee Bun &amp; Brew specializes in Vietnamese-inspired bahn mi and nitro cold brew. Its freshly prepared rolls and rice-paper wraps earn high marks for balance of flavours and speedy service, ideal for a satisfying midday bite on the go.</p>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-bold mb-3">Evening and Special-Occasion Dining</h2>
+                    <p class="text-gray-700 mb-4">When the sun sets, James Street’s atmosphere shifts to one of intimate dinners and sophisticated sips.</p>
+                    <p class="text-gray-700 mb-4">Paloma Wine Bar transforms 1/12 James Street into a neighbourhood haven for wine lovers. Operated by the team behind Restaurant Labart, its extensive by-the-glass list champions minimal-intervention producers. Guests appreciate the relaxed setting for sampling new varietals alongside small-plate pairings crafted from seasonal ingredients.</p>
+                    <p class="text-gray-700 mb-4">Oi Izakaya channels the spirit of a Japanese drinking den in a tucked-away alley off James Street. Known for its okonomiyaki, house-made gyozas, and sashimi, it also offers an impressive whisky and sake selection. Reviewers highlight the authenticity of the food and the warm atmosphere that recalls Tokyo’s izakayas.</p>
+                    <p class="text-gray-700">Maman Bar &amp; Kitchen brings Mediterranean flavours to James Street with generous share plates of meze, grilled dishes, and artisan cocktails. Its white-washed interiors and communal tables foster a leisurely, convivial vibe that reviewers note makes every visit feel like a small celebration.</p>
+                </section>
+
+                <section>
+                    <h2 class="text-3xl font-bold mb-3">Insider Tips and Practical Details</h2>
+                    <p class="text-gray-700 mb-4">To make the most of James Street’s dining scene, keep these practical suggestions in mind:</p>
+                    <ul class="list-disc list-inside text-gray-700 space-y-2 mb-4">
+                        <li>Book ahead for dinner at Paloma and Oi Izakaya, especially on weekends when walk-in availability is limited.</li>
+                        <li>Aim for weekday brunch at Social Brew or Quest to beat the lines and enjoy a more relaxed pace.</li>
+                        <li>Street parking along James Street is free before 9 AM and metered thereafter; multiple public lots and nearby bus stops offer alternatives.</li>
+                        <li>For the latest menus, special events, and reservation options, visit each venue’s official website or social media channels.</li>
+                    </ul>
+                    <p class="text-gray-700">By exploring James Street Burleigh through this local’s guide, you will experience the best cafés, bars, and restaurants that define Burleigh Heads in 2025. Whether you seek the perfect morning coffee, a casual lunch, or an intimate evening out, the offerings along James Street promise a friendly, informative, and memorable culinary journey.</p>
+                </section>
+            </div>
+        </article>
+    </main>
+
+    <footer class="bg-gray-800 text-white mt-12">
+        <div class="container mx-auto px-6 py-8 text-center">
+            <p>&copy; 2025 ParadiseGrove.com. All Rights Reserved.</p>
+            <p class="text-sm text-gray-400 mt-2">Your independent guide to the Gold Coast.</p>
+        </div>
+    </footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an article on James Street dining in `food/`
- link the new guide from the food index page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c5b46f8888321b76e38d6f89e0ae8