### PR TITLE
Add standalone About and Contact pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>About Paradise Grove</title>
+    <meta name="description" content="Learn about Paradise Grove, an independent travel guide to Burleigh Heads and the Gold Coast.">
+    <meta name="keywords" content="Paradise Grove, about us, Burleigh Heads travel guide">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+    </style>
+</head>
+<body class="bg-gray-50">
+    <header class="bg-white/90 backdrop-blur-md sticky top-0 z-50 shadow-sm">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex items-center justify-between">
+                <a href="/PG_Site/" class="text-2xl font-bold text-gray-900" aria-label="Back to ParadiseGrove.com Homepage">
+                    Paradise<span class="text-teal-500">Grove</span>.com
+                </a>
+                <a href="/PG_Site/" class="text-sm text-gray-500 hover:text-teal-500 transition duration-300">&larr; Back to Main Guide</a>
+            </div>
+        </nav>
+    </header>
+
+    <main class="container mx-auto px-6 py-12 max-w-4xl">
+        <header class="text-center mb-12">
+            <h1 class="text-4xl md:text-5xl font-extrabold leading-tight text-gray-900">About Paradise Grove</h1>
+        </header>
+        <section class="prose mx-auto">
+            <h2>Welcome to Paradise Grove</h2>
+            <p>Your independent guide to the best of Burleigh Heads and the Gold Coast. Our mission is to help visitors and locals discover the region&rsquo;s most memorable experiences, from hidden beaches and scenic walks to the top places to eat, stay, and explore.</p>
+            <h2>Who We Are</h2>
+            <p>Paradise Grove is a travel and lifestyle website created by passionate enthusiasts who love sharing authentic, first-hand recommendations and practical tips to make your trip planning easy and enjoyable. Our content is thoroughly researched, regularly updated, and always focused on what matters most to travellers and the local community.</p>
+            <h2>What We Offer</h2>
+            <p>We provide in-depth guides covering attractions, dining, accommodation, and activities. Our local insights include tips from real visitors and hidden gems. We strive to keep our information current so you can plan with confidence. Our recommendations are editorially independent and based on genuine experiences.</p>
+            <h2>Why Trust Us?</h2>
+            <p>Our goal is to provide honest, useful, and unbiased information. We are not affiliated with any single business or tourism board, and our recommendations are based on local knowledge, real visitor feedback, and personal experience.</p>
+            <p>Paradise Grove participates in affiliate programs, which means we may earn a commission if you book or purchase through our links. This helps support the site and allows us to keep our content free and up to date. We only recommend products and services we truly believe in.</p>
+            <h2>Contact Paradise Grove</h2>
+            <p>We love hearing from readers, local businesses, and fellow travellers. Whether you have a question, want to share a tip, or are interested in working together, please <a href="contact.html" class="text-teal-600 underline hover:text-teal-800">get in touch</a>.</p>
+        </section>
+    </main>
+
+    <footer class="bg-gray-800 text-white mt-12">
+        <div class="container mx-auto px-6 py-8 text-center">
+            <p>&copy; 2025 ParadiseGrove.com. All Rights Reserved.</p>
+            <p class="text-sm text-gray-400 mt-2">Your independent guide to the Gold Coast.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Contact Paradise Grove</title>
+    <meta name="description" content="Get in touch with the team at Paradise Grove using our contact form.">
+    <meta name="keywords" content="contact Paradise Grove, travel guide contact form">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap" rel="stylesheet">
+    <style>
+        body { font-family: 'Inter', sans-serif; }
+    </style>
+</head>
+<body class="bg-gray-50">
+    <header class="bg-white/90 backdrop-blur-md sticky top-0 z-50 shadow-sm">
+        <nav class="container mx-auto px-6 py-4">
+            <div class="flex items-center justify-between">
+                <a href="/PG_Site/" class="text-2xl font-bold text-gray-900" aria-label="Back to ParadiseGrove.com Homepage">
+                    Paradise<span class="text-teal-500">Grove</span>.com
+                </a>
+                <a href="/PG_Site/" class="text-sm text-gray-500 hover:text-teal-500 transition duration-300">&larr; Back to Main Guide</a>
+            </div>
+        </nav>
+    </header>
+
+    <main class="container mx-auto px-6 py-12 max-w-2xl">
+        <header class="text-center mb-8">
+            <h1 class="text-4xl md:text-5xl font-extrabold leading-tight text-gray-900">Contact Us</h1>
+            <p class="mt-2 text-gray-600">Send us a message and we'll get back to you soon.</p>
+        </header>
+
+        <form action="https://formspree.io/BeachFunAffiliate@gmail.com" method="POST" class="bg-white shadow-md rounded px-8 pt-6 pb-8 mb-4">
+            <label class="block mb-4">
+                <span class="text-gray-700">Your Name</span>
+                <input required name="name" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" placeholder="Your Name">
+            </label>
+            <label class="block mb-4">
+                <span class="text-gray-700">Email Address</span>
+                <input required name="email" type="email" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" placeholder="you@example.com">
+            </label>
+            <label class="block mb-4">
+                <span class="text-gray-700">Message</span>
+                <textarea required name="message" rows="5" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm" placeholder="Your message"></textarea>
+            </label>
+            <div class="text-center">
+                <button type="submit" class="bg-teal-500 hover:bg-teal-600 text-white font-bold py-2 px-6 rounded">Send Message</button>
+            </div>
+        </form>
+        <p class="text-sm text-gray-500">This form uses <a href="https://formspree.io" class="underline">Formspree</a> to securely send your message. We'll reply as soon as possible.</p>
+    </main>
+
+    <footer class="bg-gray-800 text-white mt-12">
+        <div class="container mx-auto px-6 py-8 text-center">
+            <p>&copy; 2025 ParadiseGrove.com. All Rights Reserved.</p>
+            <p class="text-sm text-gray-400 mt-2">Your independent guide to the Gold Coast.</p>
+        </div>
+    </footer>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -42,14 +42,16 @@
 
                 <div class="hidden md:flex items-center space-x-6">
                     <a href="#guides" class="text-gray-600 hover:text-teal-500 transition duration-300">Guides</a>
-                    <a href="#about" class="text-gray-600 hover:text-teal-500 transition duration-300">About</a>
+                    <a href="about.html" class="text-gray-600 hover:text-teal-500 transition duration-300">About</a>
+                    <a href="contact.html" class="text-gray-600 hover:text-teal-500 transition duration-300">Contact</a>
                     <a href="#disclaimer" class="text-sm bg-amber-100 text-amber-800 px-3 py-1 rounded-full hover:bg-amber-200 transition duration-300">Disclaimer</a>
                 </div>
             </div>
 
             <div id="menu" class="hidden md:hidden mt-4">
                 <a href="#guides" class="block py-2 text-gray-600 hover:text-teal-500">Guides</a>
-                <a href="#about" class="block py-2 text-gray-600 hover:text-teal-500">About</a>
+                <a href="about.html" class="block py-2 text-gray-600 hover:text-teal-500">About</a>
+                <a href="contact.html" class="block py-2 text-gray-600 hover:text-teal-500">Contact</a>
                 <a href="#disclaimer" class="block mt-2 py-2 text-amber-800">Disclaimer</a>
             </div>
         </nav>


### PR DESCRIPTION
## Summary
- add new `about.html` with background on Paradise Grove
- add `contact.html` featuring a Formspree contact form
- update navigation links on the home page to link to the new pages
- tweak the contact form text

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686c69cfa9c48321930c771e55baf4df